### PR TITLE
자동 배포시 스프링 이미지를 도커 허브에 등록하지 않는 이슈

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,5 +53,6 @@ jobs:
             cd /home/aio
             export DOCKER_HUB_USERNAME=${{ secrets.DOCKER_HUB_USERNAME }}
             docker-compose down
+            docker-compose pull
             docker image prune -a -f
             docker-compose -f docker-compose.yml up --build -d


### PR DESCRIPTION
docker-compose pull을 통해 항상 최신 이미지를 다운로드 하도록 강제하는 것으로 작업을 완료했습니다.